### PR TITLE
Fix NPE in Morph when MorphModule varargs array is null

### DIFF
--- a/core/src/main/java/net/morph/Morph.java
+++ b/core/src/main/java/net/morph/Morph.java
@@ -39,7 +39,7 @@ public class Morph {
 
     private Morph(MorphModule... modules) {
         this.modules = modules == null ? new MorphModule[0] : modules;
-        for (MorphModule module : modules) {
+        for (MorphModule module : this.modules) {
             Collections.addAll(operators, module.getOperators());
         }
     }

--- a/core/src/test/java/net/morph/operation/ConvertTest.java
+++ b/core/src/test/java/net/morph/operation/ConvertTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertSame;
 import net.morph.Morph;
 import net.morph.MorphContext;
 import net.morph.MorphModule;
+import net.morph.OperationException;
 import net.morph.TypeLiteral;
 import net.morph.operator.DefaultImmutableChecker;
 import net.morph.position.Ref;
@@ -35,6 +36,13 @@ public class ConvertTest {
     @Before
     public void setup() {
         morphContext = Morph.usingModules(MorphModule.create().withOperators(new DefaultImmutableChecker())).context();
+    }
+
+    @Test(expected=OperationException.class)
+    public void tesConverttUsingNullModules() {
+        Morph morph = Morph.usingModules((MorphModule[])null);
+        MorphContext morphContext = morph.context();
+        assertEquals(null, morphContext.eval(Convert.to(String.class, Ref.to(""))));
     }
 
     @Test


### PR DESCRIPTION
Although the null argument was being treated some lines above, it was using the local variable instead of the member variable. Tests in place.
